### PR TITLE
Add Style/StyleRef types to represent "fill or stroke"

### DIFF
--- a/src/brush.rs
+++ b/src/brush.rs
@@ -41,6 +41,17 @@ pub enum BrushRef<'a> {
     Image(&'a Image),
 }
 
+impl<'a> BrushRef<'a> {
+    /// Converts the reference to an owned brush.
+    pub fn to_owned(&self) -> Brush {
+        match self {
+            Self::Solid(color) => Brush::Solid(*color),
+            Self::Gradient(gradient) => Brush::Gradient((*gradient).clone()),
+            Self::Image(image) => Brush::Image((*image).clone()),
+        }
+    }
+}
+
 impl From<Color> for BrushRef<'_> {
     fn from(color: Color) -> Self {
         Self::Solid(color)

--- a/src/font.rs
+++ b/src/font.rs
@@ -4,7 +4,7 @@
 use super::Blob;
 
 /// Owned shareable font resource.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Font {
     /// Blob containing the content of the font file.
     pub data: Blob<u8>,

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -60,7 +60,7 @@ impl From<(f32, Color)> for ColorStop {
 pub type ColorStops = SmallVec<[ColorStop; 4]>;
 
 /// Properties for the supported gradient types.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum GradientKind {
     /// Gradient that transitions between two or more colors along a line.
     Linear {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ pub use color::Color;
 pub use font::Font;
 pub use gradient::{ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind};
 pub use image::{Format, Image};
-pub use style::{Cap, Dashes, Draw, DrawRef, Fill, Join, Stroke};
+pub use style::{Cap, Dashes, Fill, Join, Stroke, Style, StyleRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ pub use color::Color;
 pub use font::Font;
 pub use gradient::{ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind};
 pub use image::{Format, Image};
-pub use style::{Cap, Dashes, Fill, Join, Stroke};
+pub use style::{Cap, Dashes, Draw, DrawRef, Fill, Join, Stroke};

--- a/src/style.rs
+++ b/src/style.rs
@@ -138,20 +138,20 @@ pub type Dashes = SmallVec<[f32; 4]>;
 
 /// Describes draw style-- either a fill or stroke.
 #[derive(Clone, Debug)]
-pub enum Draw {
+pub enum Style {
     /// Filled draw operation.
     Fill(Fill),
     /// Stroked draw operation.
     Stroke(Stroke),
 }
 
-impl From<Fill> for Draw {
+impl From<Fill> for Style {
     fn from(fill: Fill) -> Self {
         Self::Fill(fill)
     }
 }
 
-impl From<Stroke> for Draw {
+impl From<Stroke> for Style {
     fn from(stroke: Stroke) -> Self {
         Self::Stroke(stroke)
     }
@@ -162,40 +162,40 @@ impl From<Stroke> for Draw {
 /// This is useful for methods that would like to accept draw styles by reference. Defining
 /// the type as `impl<Into<DrawRef>>` allows accepting types like `&Stroke` or `Fill`
 /// directly without cloning or allocating.
-pub enum DrawRef<'a> {
+pub enum StyleRef<'a> {
     /// Filled draw operation.
     Fill(Fill),
     /// Stroked draw operation.
     Stroke(&'a Stroke),
 }
 
-impl<'a> DrawRef<'a> {
+impl<'a> StyleRef<'a> {
     /// Converts the reference to an owned draw.
-    pub fn to_owned(&self) -> Draw {
+    pub fn to_owned(&self) -> Style {
         match self {
-            Self::Fill(fill) => Draw::Fill(*fill),
-            Self::Stroke(stroke) => Draw::Stroke((*stroke).clone()),
+            Self::Fill(fill) => Style::Fill(*fill),
+            Self::Stroke(stroke) => Style::Stroke((*stroke).clone()),
         }
     }
 }
 
-impl From<Fill> for DrawRef<'_> {
+impl From<Fill> for StyleRef<'_> {
     fn from(fill: Fill) -> Self {
         Self::Fill(fill)
     }
 }
 
-impl<'a> From<&'a Stroke> for DrawRef<'a> {
+impl<'a> From<&'a Stroke> for StyleRef<'a> {
     fn from(stroke: &'a Stroke) -> Self {
         Self::Stroke(stroke)
     }
 }
 
-impl<'a> From<&'a Draw> for DrawRef<'a> {
-    fn from(draw: &'a Draw) -> Self {
+impl<'a> From<&'a Style> for StyleRef<'a> {
+    fn from(draw: &'a Style) -> Self {
         match draw {
-            Draw::Fill(fill) => Self::Fill(*fill),
-            Draw::Stroke(stroke) => Self::Stroke(stroke),
+            Style::Fill(fill) => Self::Fill(*fill),
+            Style::Stroke(stroke) => Self::Stroke(stroke),
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -135,3 +135,67 @@ impl Stroke {
 
 /// Collection of values representing lengths in a dash pattern.
 pub type Dashes = SmallVec<[f32; 4]>;
+
+/// Describes draw style-- either a fill or stroke.
+#[derive(Clone, Debug)]
+pub enum Draw {
+    /// Filled draw operation.
+    Fill(Fill),
+    /// Stroked draw operation.
+    Stroke(Stroke),
+}
+
+impl From<Fill> for Draw {
+    fn from(fill: Fill) -> Self {
+        Self::Fill(fill)
+    }
+}
+
+impl From<Stroke> for Draw {
+    fn from(stroke: Stroke) -> Self {
+        Self::Stroke(stroke)
+    }
+}
+
+/// Reference to a draw style.
+///
+/// This is useful for methods that would like to accept draw styles by reference. Defining
+/// the type as `impl<Into<DrawRef>>` allows accepting types like `&Stroke` or `Fill`
+/// directly without cloning or allocating.
+pub enum DrawRef<'a> {
+    /// Filled draw operation.
+    Fill(Fill),
+    /// Stroked draw operation.
+    Stroke(&'a Stroke),
+}
+
+impl<'a> DrawRef<'a> {
+    /// Converts the reference to an owned draw.
+    pub fn to_owned(&self) -> Draw {
+        match self {
+            Self::Fill(fill) => Draw::Fill(*fill),
+            Self::Stroke(stroke) => Draw::Stroke((*stroke).clone()),
+        }
+    }
+}
+
+impl From<Fill> for DrawRef<'_> {
+    fn from(fill: Fill) -> Self {
+        Self::Fill(fill)
+    }
+}
+
+impl<'a> From<&'a Stroke> for DrawRef<'a> {
+    fn from(stroke: &'a Stroke) -> Self {
+        Self::Stroke(stroke)
+    }
+}
+
+impl<'a> From<&'a Draw> for DrawRef<'a> {
+    fn from(draw: &'a Draw) -> Self {
+        match draw {
+            Draw::Fill(fill) => Self::Fill(*fill),
+            Draw::Stroke(stroke) => Self::Stroke(stroke),
+        }
+    }
+}


### PR DESCRIPTION
In the spirit of `Brush` and `BrushRef` these are a pair of owned and reference types to abstractly represent either a fill or a stroke.

The motivation is for linebender/vello#284 where trying to parameterize on draw style within a builder that is consumed by `fill` or `stroke` methods is ergonomically painful. The intention is to replace those methods with a single `draw` method taking `impl Into<StyleRef>` as the first parameter. This will likely extend to other `SceneBuilder` methods in the future.

I could add these types directly to vello but it probably makes more sense for them to live here.