### PR TITLE
fmt::Debug for Blob: Use finish_non_exhaustive.

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -13,7 +13,9 @@ pub struct Blob<T> {
 
 impl<T> fmt::Debug for Blob<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Blob").field("id", &self.id).finish()
+        f.debug_struct("Blob")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
This indicates that the debug output doesn't include all fields.