### PR TITLE
Bump kurbo and remove Stroke

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ homepage = "https://github.com/linebender/peniko"
 readme = "README.md"
 
 [dependencies]
-kurbo = "0.9.5"
+kurbo = "0.10.2"
 smallvec = "1.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,4 @@ pub use color::Color;
 pub use font::Font;
 pub use gradient::{ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind};
 pub use image::{Format, Image};
-pub use style::{Cap, Dashes, Fill, Join, Stroke, Style, StyleRef};
+pub use style::{Fill, Style, StyleRef};

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,8 +1,7 @@
 // Copyright 2022 The peniko authors.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use core::borrow::Borrow;
-use smallvec::SmallVec;
+use kurbo::Stroke;
 
 /// Describes the rule that determines the interior portion of a shape.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -12,137 +11,6 @@ pub enum Fill {
     /// Even-odd fill rule.
     EvenOdd,
 }
-
-/// Defines the connection between two segments of a [stroke](Stroke).
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Join {
-    /// A straight line connecting the segments.
-    Bevel,
-    /// The segments are extended to their natural intersection point.
-    Miter,
-    /// An arc between the segments.
-    Round,
-}
-
-/// Defines the shape to be drawn at the ends of a [stroke](Stroke).
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Cap {
-    /// Flat cap.
-    Butt,
-    /// Square cap with dimensions equal to half the stroke width.
-    Square,
-    /// Rounded cap with radius equal to half the stroke width.
-    Round,
-}
-
-/// Describes the visual style of a stroke.
-#[derive(Clone, Debug)]
-pub struct Stroke {
-    /// Width of the stroke.
-    pub width: f32,
-    /// Style for connecting segments of the stroke.
-    pub join: Join,
-    /// Limit for miter joins.
-    pub miter_limit: f32,
-    /// Style for capping the beginning of an open subpath.
-    pub start_cap: Cap,
-    /// Style for capping the end of an open subpath.
-    pub end_cap: Cap,
-    /// Lengths of dashes in alternating on/off order.
-    pub dash_pattern: Dashes,
-    /// Offset of the first dash.
-    pub dash_offset: f32,
-    /// True if the stroke width should be affected by the scale of a
-    /// transform.
-    pub scale: bool,
-}
-
-impl Default for Stroke {
-    fn default() -> Self {
-        Self {
-            width: 1.0,
-            join: Join::Round,
-            miter_limit: 4.0,
-            start_cap: Cap::Round,
-            end_cap: Cap::Round,
-            dash_pattern: Default::default(),
-            dash_offset: 0.0,
-            scale: true,
-        }
-    }
-}
-
-impl Stroke {
-    /// Creates a new stroke with the specified width.
-    #[must_use]
-    pub fn new(width: f32) -> Self {
-        Self {
-            width,
-            ..Default::default()
-        }
-    }
-
-    /// Builder method for setting the join style.
-    #[must_use]
-    pub fn with_join(mut self, join: Join) -> Self {
-        self.join = join;
-        self
-    }
-
-    /// Builder method for setting the limit for miter joins.
-    #[must_use]
-    pub fn with_miter_limit(mut self, limit: f32) -> Self {
-        self.miter_limit = limit;
-        self
-    }
-
-    /// Builder method for setting the cap style for the start of the stroke.
-    #[must_use]
-    pub fn with_start_cap(mut self, cap: Cap) -> Self {
-        self.start_cap = cap;
-        self
-    }
-
-    /// Builder method for setting the cap style for the end of the stroke.
-    #[must_use]
-    pub fn with_end_cap(mut self, cap: Cap) -> Self {
-        self.end_cap = cap;
-        self
-    }
-
-    /// Builder method for setting the cap style.
-    #[must_use]
-    pub fn with_caps(mut self, cap: Cap) -> Self {
-        self.start_cap = cap;
-        self.end_cap = cap;
-        self
-    }
-
-    /// Builder method for setting the dashing parameters.
-    #[must_use]
-    pub fn with_dashes<P>(mut self, offset: f32, pattern: P) -> Self
-    where
-        P: IntoIterator,
-        P::Item: Borrow<f32>,
-    {
-        self.dash_offset = offset;
-        self.dash_pattern.clear();
-        self.dash_pattern
-            .extend(pattern.into_iter().map(|dash| *dash.borrow()));
-        self
-    }
-
-    /// Builder method for setting whether or not the stroke should be affected
-    /// by the scale of any applied transform.
-    #[must_use]
-    pub fn with_scale(mut self, yes: bool) -> Self {
-        self.scale = yes;
-        self
-    }
-}
-
-/// Collection of values representing lengths in a dash pattern.
-pub type Dashes = SmallVec<[f32; 4]>;
 
 /// Describes draw style-- either a [fill](Fill) or [stroke](Stroke).
 ///


### PR DESCRIPTION
Now that kurbo 0.10 can represent stroke styles, remove it from this crate. Note that this also removes the `scale` parameter, which was used to model the non-scaling stroke vector effect in SVG.

The `Fill` and `Style` enums are kept, as fill rule represents a rendering choice and not path geometry, and is not (at least at the moment) represented in kurbo.