### PR TITLE
Remove unneeded Cargo.toml metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "peniko"
 version = "0.1.0"
-authors = ["Chad Brokaw <cbrokaw@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Primitive types for styling vector graphics"
 keywords = ["graphics", "vector", "style"]
 categories = ["graphics"]
 repository = "https://github.com/linebender/peniko"
-homepage = "https://github.com/linebender/peniko"
+# homepage = "https://linebender.org/peniko" - no homepage has been created yet
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "Primitive types for styling vector graphics"
 keywords = ["graphics", "vector", "style"]
 categories = ["graphics"]
 repository = "https://github.com/linebender/peniko"
-# homepage = "https://linebender.org/peniko" - no homepage has been created yet
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
See https://rust-lang.github.io/rfcs/3052-optional-authors-field.html

I also don't think it's useful to have a homepage which is the same as the repository.

@dfrg requested your review, as you are the listed author

Looking at #17