### PR TITLE
Updates to support parley

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -104,6 +104,12 @@ impl<T> Blob<T> {
         self.id
     }
 
+    /// Returns the number of existing strong pointers to this blob.
+    #[must_use]
+    pub fn strong_count(&self) -> usize {
+        Arc::strong_count(&self.data)
+    }
+
     /// Downgrades the shared blob to a weak reference.
     #[must_use]
     pub fn downgrade(&self) -> WeakBlob<T> {

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -28,6 +28,12 @@ impl From<Gradient> for Brush {
     }
 }
 
+impl Default for Brush {
+    fn default() -> Self {
+        Self::Solid(Color::default())
+    }
+}
+
 /// Reference to a [brush](Brush).
 ///
 /// This is useful for methods that would like to accept brushes by reference. Defining


### PR DESCRIPTION
I'm taking peniko as a new dependency in parley, mostly to make use of the Font/Blob types for better integration with vello and xilem.

This adds a few missing bits to make that happen:
* Blob gains a strong_count() method
* Brush gets a Default impl
