### PR TITLE
add features for kurbo's std/libm features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,11 @@ jobs:
       # - name: restore cache
       #   uses: Swatinem/rust-cache@v2
 
-      # We don't currently have features, so there's no need to run these checks
-      # - name: cargo clippy (no default features)
-      #   run: cargo clippy --workspace --lib --bins --no-default-features -- -D warnings
+      - name: cargo clippy (no default features with libm)
+        run: cargo clippy --workspace --lib --bins --no-default-features --features libm -- -D warnings
 
-      # - name: cargo clippy (no default features) (auxiliary)
-      #   run: cargo clippy --workspace --tests --benches --examples --no-default-features -- -D warnings
+      - name: cargo clippy (no default features with libm) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --no-default-features --features libm -- -D warnings
 
       - name: cargo clippy (default features)
         run: cargo clippy --workspace --lib --bins -- -D warnings
@@ -71,17 +70,22 @@ jobs:
       - name: cargo clippy (default features) (auxiliary)
         run: cargo clippy --workspace --tests --benches --examples -- -D warnings
 
-      # As above
-      # - name: cargo clippy (all features)
-      #   run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
+      - name: cargo clippy (all features)
+        run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
 
-      # - name: cargo clippy (all features) (auxiliary)
-      #   run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
+      - name: cargo clippy (all features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
 
       # At the time of writing, we don't have any tests. Nevertheless, it's better to still run this
       - name: cargo test
         run: cargo test --workspace --all-features
-  
+
+      - run: rustup target add armv7a-none-eabi
+
+      # We use armv7a as a no_std with AtomicU64
+      - name: cargo build (no-default-features + libm, no_std target)
+        run: cargo build --no-default-features --features libm --target armv7a-none-eabi
+
   clippy-msrv:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -100,12 +104,11 @@ jobs:
           toolchain: ${{ env.MINIMUM_SUPPORTED_RUST_VERSION }}
           components: clippy
 
-      # We don't currently have features, so there's no need to run these checks
-      # - name: cargo clippy (no default features)
-      #   run: cargo clippy --workspace --lib --bins --no-default-features -- -D warnings
+      - name: cargo clippy (no default features with libm)
+        run: cargo clippy --workspace --lib --bins --no-default-features --features libm -- -D warnings
 
-      # - name: cargo clippy (no default features) (auxiliary)
-      #   run: cargo clippy --workspace --tests --benches --examples --no-default-features -- -D warnings
+      - name: cargo clippy (no default features with libm) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --no-default-features --features libm -- -D warnings
 
       - name: cargo clippy (default features)
         run: cargo clippy --workspace --lib --bins -- -D warnings -A clippy::doc_markdown
@@ -113,12 +116,17 @@ jobs:
       - name: cargo clippy (default features) (auxiliary)
         run: cargo clippy --workspace --tests --benches --examples -- -D warnings -A clippy::doc_markdown
 
-      # As above
-      # - name: cargo clippy (all features)
-      #   run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
+      - name: cargo clippy (all features)
+        run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
 
-      # - name: cargo clippy (all features) (auxiliary)
-      #   run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
+      - name: cargo clippy (all features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
+
+      - run: rustup target add armv7a-none-eabi
+
+      # We use armv7a as a no_std with AtomicU64
+      - name: cargo build (no-default-features + libm, no_std target)
+        run: cargo build --no-default-features --features libm --target armv7a-none-eabi
 
   clippy-stable-wasm:
     runs-on: ubuntu-latest
@@ -135,6 +143,9 @@ jobs:
 
       - name: cargo clippy (wasm)
         run: cargo clippy --all-targets --target wasm32-unknown-unknown -- -D warnings
+
+      - name: cargo build (no-default-features + libm, wasm32)
+        run: cargo build --no-default-features --features libm --target wasm32-unknown-unknown
 
   docs:
     name: cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ readme = "README.md"
 rust-version = "1.70"
 
 [features]
-# If adding the first feature, also enable the relevant sections of .github/workflows/ci.yaml
-# (then remove this comment)
+default = ["std"]
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
 
 [dependencies]
-kurbo = "0.10.2"
+kurbo = { version = "0.11", default-features = false }
 smallvec = "1.8.0"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,9 +1,12 @@
 // Copyright 2022 The peniko authors.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Weak};
+use core::fmt;
+use core::sync::atomic::{AtomicU64, Ordering};
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::sync::{Arc, Weak};
+use alloc::vec::Vec;
 
 /// Shared data with an associated unique identifier.
 pub struct Blob<T> {

--- a/src/color.rs
+++ b/src/color.rs
@@ -3,6 +3,9 @@
 
 // Borrows code heavily from the piet (https://github.com/linebender/piet/) Color
 // type.
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[allow(unused_imports)]
+use kurbo::common::FloatFuncs as _;
 
 /// 32-bit RGBA color.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
@@ -93,7 +96,7 @@ impl Color {
                 3. * d * d * (t - 4. / 29.)
             }
         }
-        let th = h * (std::f64::consts::PI / 180.);
+        let th = h * (core::f64::consts::PI / 180.);
         let a = c * th.cos();
         let b = c * th.sin();
         let ll = (l + 16.) * (1. / 116.);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //!
 //! [`kurbo`]: https://crates.io/crates/kurbo
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // doc_markdown was updated in https://github.com/rust-lang/rust-clippy/pull/11735
 // to be more accurate, but our MSRV is earlier than that
 #![cfg_attr(not(peniko_msrv), warn(clippy::doc_markdown))]


### PR DESCRIPTION
This tries to enable the case where people want peniko with a non-default kurbo features selected.
It does not enable the --no-default-features CI tests because we inherit from kurbo the following `compile_error` when --no-default-features is selected alone.

https://github.com/linebender/kurbo/blob/6ea9f53498749703606f6f8d019fe0bc9080ea30/src/lib.rs#L83

I personally don't use this in a no_std or anything, I just wanted to go through the list of default-features given the pending release.