### PR TITLE
Standardize copyright headers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
-# This is the list of Peniko authors for copyright purposes.
+# This is the list of Peniko's significant contributors.
 #
-# This does not necessarily list everyone who has contributed code, since in
-# some cases, their employer may be the copyright holder.  To see the full list
-# of contributors, see the revision history in source control.
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
 Chad Brokaw

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of peniko authors for copyright purposes.
+# This is the list of Peniko authors for copyright purposes.
 #
 # This does not necessarily list everyone who has contributed code, since in
 # some cases, their employer may be the copyright holder.  To see the full list

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Defines the color mixing function for a [blend operation](BlendMode).

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use core::fmt;

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::{Color, Gradient, Image};

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors and piet authors.
+// Copyright 2022 the Peniko Authors and the Piet Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // Borrows code heavily from the piet (https://github.com/linebender/piet/) Color

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::Blob;

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::{Color, Extend};

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::{Blob, Extend};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A Rust 2D graphics type library

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The peniko authors.
+// Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use kurbo::Stroke;


### PR DESCRIPTION
The Linebender standard for copyright headers was decided last year in [kurbo#207](https://github.com/linebender/kurbo/issues/207) as the following:

```
// Copyright <year of file creation> the <Project> Authors
// SPDX-License-Identifier: Apache-2.0 OR MIT
```

This PR converts all file headers to this standard form, including the standard capitalization.