### PR TITLE
Add serde derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ checksum = "6e5aa9f0f96a938266bdb12928a67169e8d22c6a786fda8ed984b85e6ba93c3c"
 dependencies = [
  "arrayvec",
  "libm",
+ "serde",
  "smallvec",
 ]
 
@@ -30,7 +31,56 @@ name = "peniko"
 version = "0.1.0"
 dependencies = [
  "kurbo",
+ "serde",
+ "serde_bytes",
  "smallvec",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -38,3 +88,23 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,22 @@ rust-version = "1.70"
 default = ["std"]
 std = ["kurbo/std"]
 libm = ["kurbo/libm"]
+serde = ["smallvec/serde", "kurbo/serde", "dep:serde_bytes", "dep:serde"]
+
+[package.metadata.docs.rs]
+features = ["serde"]
 
 [dependencies]
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 kurbo = { version = "0.11.0", default-features = false }
 smallvec = "1.13.2"
+
+[dependencies.serde]
+version = "1.0.105"
+optional = true
+default-features = false
+features = ["alloc", "derive"]
+
+[dependencies.serde_bytes]
+version = "0.11.12"
+optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ kurbo = { version = "0.11.0", default-features = false }
 smallvec = "1.13.2"
 
 [dependencies.serde]
-version = "1.0.105"
+version = "1.0.197"
 optional = true
 default-features = false
 features = ["alloc", "derive"]
 
 [dependencies.serde_bytes]
-version = "0.11.12"
+version = "0.11.14"
 optional = true
 default-features = false
 features = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,5 @@ features = ["alloc", "derive"]
 [dependencies.serde_bytes]
 version = "0.11.12"
 optional = true
+default-features = false
+features = ["alloc"]

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -3,6 +3,7 @@
 
 /// Defines the color mixing function for a [blend operation](BlendMode).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub enum Mix {
     /// Default attribute which specifies no blending. The blending formula simply selects the source color.
@@ -55,6 +56,7 @@ pub enum Mix {
 
 /// Defines the layer composition function for a [blend operation](BlendMode).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub enum Compose {
     /// No regions are enabled.
@@ -92,6 +94,7 @@ pub enum Compose {
 
 /// Blend mode consisting of [color mixing](Mix) and [composition functions](Compose).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlendMode {
     /// The color mixing function.
     pub mix: Mix,

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -41,7 +41,6 @@ impl Default for Brush {
 /// the type as `impl<Into<BrushRef>>` allows accepting types like `&LinearGradient`
 /// directly without cloning or allocating.
 #[derive(Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum BrushRef<'a> {
     /// Solid color brush.
     Solid(Color),

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -7,6 +7,7 @@ use super::{Color, Gradient, Image};
 ///
 /// See also [`BrushRef`] which can be used to avoid allocations.
 #[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Brush {
     /// Solid color brush.
     Solid(Color),
@@ -40,6 +41,7 @@ impl Default for Brush {
 /// the type as `impl<Into<BrushRef>>` allows accepting types like `&LinearGradient`
 /// directly without cloning or allocating.
 #[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum BrushRef<'a> {
     /// Solid color brush.
     Solid(Color),
@@ -98,6 +100,7 @@ impl<'a> From<&'a Brush> for BrushRef<'a> {
 /// Defines how a brush is extended when the content does not
 /// fill a shape.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Extend {
     /// Extends the image by repeating the edge color of the brush.
     #[default]

--- a/src/color.rs
+++ b/src/color.rs
@@ -9,6 +9,7 @@ use kurbo::common::FloatFuncs as _;
 
 /// 32-bit RGBA color.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     /// Red component.
     pub r: u8,

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -13,6 +13,7 @@ use core::{
 
 /// Offset and color of a transition point in a [gradient](Gradient).
 #[derive(Copy, Clone, PartialOrd, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColorStop {
     /// Normalized offset of the stop.
     pub offset: f32,
@@ -62,6 +63,7 @@ pub type ColorStops = SmallVec<[ColorStop; 4]>;
 
 /// Properties for the supported [gradient](Gradient) types.
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GradientKind {
     /// Gradient that transitions between two or more colors along a line.
     Linear {
@@ -95,6 +97,7 @@ pub enum GradientKind {
 
 /// Definition of a gradient that transitions between two or more colors.
 #[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gradient {
     /// Kind and properties of the gradient.
     pub kind: GradientKind,

--- a/src/image.rs
+++ b/src/image.rs
@@ -5,6 +5,7 @@ use super::{Blob, Extend};
 
 /// Defines the pixel format of an [image](Image).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Format {
     /// 32-bit RGBA with 8-bit channels.
     Rgba8,
@@ -27,6 +28,7 @@ impl Format {
 
 /// Owned shareable image resource.
 #[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Image {
     /// Blob containing the image data.
     pub data: Blob<u8>,

--- a/src/style.rs
+++ b/src/style.rs
@@ -5,6 +5,7 @@ use kurbo::Stroke;
 
 /// Describes the rule that determines the interior portion of a shape.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Fill {
     /// Non-zero fill rule.
     NonZero,
@@ -16,6 +17,7 @@ pub enum Fill {
 ///
 /// See also [`StyleRef`] which can be used to avoid allocations.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Style {
     /// Filled draw operation.
     Fill(Fill),


### PR DESCRIPTION
This splits off just the serde support from #16 which originally contained both serde and schemars features.
None of my projects need schemars support, I mostly added it for feature parity with kurbo, but supporting blobs nicely required some upstream patches.

This adds a dependency on `serde_bytes` for `Blob` which is also a dtolnay crate.