### PR TITLE
Remove `Default` in `Color`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -8,7 +8,7 @@
 use kurbo::common::FloatFuncs as _;
 
 /// 32-bit RGBA color.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     /// Red component.


### PR DESCRIPTION
So we had this argument in https://github.com/linebender/xilem/pull/226#discussion_r1581831573
And I think `Default` for `Color` doesn't really make sense, especially if `Color::a` is `0`.

Is there a reason for implementing `Default` for it?

(CI breaks currently because of this, I'm waiting for initial feedback before fixing it (i.e. `impl Default` for the types depending on `Color::default`))