### PR TITLE
lints: Enable `warn(unused_qualifications)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/linebender/peniko"
 readme = "README.md"
 # We support from Rust 1.70 to ensure that CI uses the sparse registry protocol.
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files.
+# TODO: When this hits 1.74, move lint configuration into this file via a lints table.
 rust-version = "1.70"
 
 [features]

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -6,10 +6,7 @@ use super::{Color, Extend};
 use kurbo::Point;
 use smallvec::SmallVec;
 
-use core::{
-    cmp,
-    hash::{Hash, Hasher},
-};
+use core::hash::{Hash, Hasher};
 
 /// Offset and color of a transition point in a [gradient](Gradient).
 #[derive(Copy, Clone, PartialOrd, Default, Debug)]
@@ -29,13 +26,13 @@ impl Hash for ColorStop {
 }
 
 // Override PartialEq to use to_bits for the offset to match with the Hash impl
-impl cmp::PartialEq for ColorStop {
+impl PartialEq for ColorStop {
     fn eq(&self, other: &Self) -> bool {
         self.offset.to_bits() == other.offset.to_bits() && self.color == other.color
     }
 }
 
-impl cmp::Eq for ColorStop {}
+impl Eq for ColorStop {}
 
 impl ColorStop {
     /// Returns the color stop with the alpha component multiplied by the specified

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! [`kurbo`]: https://crates.io/crates/kurbo
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![warn(clippy::doc_markdown)]
+#![warn(clippy::doc_markdown, unused_qualifications)]
 
 mod blend;
 mod blob;


### PR DESCRIPTION
This helps point out where the code can be more concise with an identifier already being in scope and not needing qualifications.