### PR TITLE
Add `with_alpha_factor` to `BrushRef`/`Brush`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### Added
 
-...
+- [#40](https://github.com/linebender/peniko/pull/40) - Breaking change: An `alpha` multiplier to `Image` by [@DJMcNab](https://github.com/DJMcNab)
 
 ### Changed
 

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -85,14 +85,14 @@ impl<'a> BrushRef<'a> {
             self.to_owned()
         } else {
             match *self {
-                BrushRef::Solid(color) => color.with_alpha_factor(alpha as f32).into(),
+                BrushRef::Solid(color) => color.with_alpha_factor(alpha).into(),
                 BrushRef::Gradient(gradient) => Brush::Gradient(Gradient {
                     kind: gradient.kind,
                     extend: gradient.extend,
                     stops: gradient
                         .stops
                         .iter()
-                        .map(|stop| stop.with_alpha_factor(alpha as f32))
+                        .map(|stop| stop.with_alpha_factor(alpha))
                         .collect(),
                 }),
                 BrushRef::Image(image) => image.clone().with_alpha_factor(alpha).into(),

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -29,9 +29,25 @@ impl From<Gradient> for Brush {
     }
 }
 
+impl From<Image> for Brush {
+    fn from(value: Image) -> Self {
+        Self::Image(value)
+    }
+}
+
 impl Default for Brush {
     fn default() -> Self {
         Self::Solid(Color::default())
+    }
+}
+
+impl Brush {
+    /// Returns the brush with the alpha component multiplied by the specified
+    /// factor.
+    #[must_use]
+    pub fn with_alpha_factor(&self, alpha: f32) -> Self {
+        let result: BrushRef = self.into();
+        result.with_alpha_factor(alpha)
     }
 }
 
@@ -40,7 +56,7 @@ impl Default for Brush {
 /// This is useful for methods that would like to accept brushes by reference. Defining
 /// the type as `impl<Into<BrushRef>>` allows accepting types like `&LinearGradient`
 /// directly without cloning or allocating.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum BrushRef<'a> {
     /// Solid color brush.
     Solid(Color),
@@ -58,6 +74,33 @@ impl<'a> BrushRef<'a> {
             Self::Solid(color) => Brush::Solid(*color),
             Self::Gradient(gradient) => Brush::Gradient((*gradient).clone()),
             Self::Image(image) => Brush::Image((*image).clone()),
+        }
+    }
+
+    /// Returns the brush with the alpha component multiplied by the specified
+    /// factor.
+    #[must_use]
+    pub fn with_alpha_factor(&self, alpha: f32) -> Brush {
+        if alpha == 1.0 {
+            self.to_owned()
+        } else {
+            match *self {
+                BrushRef::Solid(color) => color.with_alpha_factor(alpha as f32).into(),
+                BrushRef::Gradient(gradient) => Brush::Gradient(Gradient {
+                    kind: gradient.kind,
+                    extend: gradient.extend,
+                    stops: gradient
+                        .stops
+                        .iter()
+                        .map(|stop| stop.with_alpha_factor(alpha as f32))
+                        .collect(),
+                }),
+                BrushRef::Image(image) => {
+                    let mut result = image.clone();
+                    result.alpha = ((result.alpha as f32) * alpha).round() as u8;
+                    result.into()
+                }
+            }
         }
     }
 }

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -95,11 +95,7 @@ impl<'a> BrushRef<'a> {
                         .map(|stop| stop.with_alpha_factor(alpha as f32))
                         .collect(),
                 }),
-                BrushRef::Image(image) => {
-                    let mut result = image.clone();
-                    result.alpha = ((result.alpha as f32) * alpha).round() as u8;
-                    result.into()
-                }
+                BrushRef::Image(image) => image.clone().with_alpha_factor(alpha).into(),
             }
         }
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -38,8 +38,10 @@ pub struct Image {
     pub width: u32,
     /// Height of the image.
     pub height: u32,
-    /// Extend mode
+    /// Extend mode.
     pub extend: Extend,
+    /// An additional alpha multiplier to use with the image.
+    pub alpha: u8,
 }
 
 impl Image {
@@ -52,6 +54,8 @@ impl Image {
             width,
             height,
             extend: Extend::Pad,
+            // Opaque
+            alpha: u8::MAX,
         }
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -66,8 +66,7 @@ impl Image {
         self
     }
 
-    /// Returns the brush with the alpha component multiplied by the specified
-    /// factor.
+    /// Builder method for setting the image alpha.
     #[must_use]
     pub fn with_alpha_factor(mut self, alpha: f32) -> Self {
         self.alpha = ((self.alpha as f32) * alpha).round() as u8;

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,6 +1,10 @@
 // Copyright 2022 the Peniko Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[allow(unused_imports)]
+use kurbo::common::FloatFuncs as _;
+
 use super::{Blob, Extend};
 
 /// Defines the pixel format of an [image](Image).

--- a/src/image.rs
+++ b/src/image.rs
@@ -65,4 +65,12 @@ impl Image {
         self.extend = mode;
         self
     }
+
+    /// Returns the brush with the alpha component multiplied by the specified
+    /// factor.
+    #[must_use]
+    pub fn with_alpha_factor(mut self, alpha: f32) -> Self {
+        self.alpha = ((self.alpha as f32) * alpha).round() as u8;
+        self
+    }
 }


### PR DESCRIPTION
Fixes #27

The key feature is adding `alpha` to `Image`. There were also a couple of other papercuts which I've tweaked