### PR TITLE
Match CI doc testing with docs.rs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,15 +260,17 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      # We test documentation using nightly to match docs.rs. This prevents potential breakages
+      # We test documentation using nightly to match docs.rs.
       - name: cargo doc
-        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: '--cfg docsrs -D warnings'
 
-  # If this fails, consider changing your text or adding something to .typos.toml
+  # If this fails, consider changing your text or adding something to .typos.toml.
   typos:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: check typos
-        uses: crate-ci/typos@v1.26.0
+        uses: crate-ci/typos@v1.27.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,18 @@ readme = "README.md"
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 rust-version = "1.70"
 
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
 [features]
 default = ["std"]
 std = ["kurbo/std"]
 libm = ["kurbo/libm"]
 mint = ["kurbo/mint"]
 serde = ["smallvec/serde", "kurbo/serde", "dep:serde_bytes", "dep:serde"]
-
-[package.metadata.docs.rs]
-features = ["serde"]
 
 [dependencies]
 # NOTE: Make sure to keep this in sync with the version badge in README.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! [`kurbo`]: https://crates.io/crates/kurbo
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(unused_crate_dependencies)]
 #![warn(clippy::print_stdout, clippy::print_stderr)]
 // There are lots of conversion to u8 color field, which in degenerate cases might not work


### PR DESCRIPTION
* Remove `-Zunstable-options -Zrustdoc-scrape-examples` from CI. It wasn't even enabled for docs.rs and we don't have any examples, so not worth enabling scraping at this point.
* Treat doc warnings as errors. Historically we've not done so due to various `rustdoc` bugs giving false positives but I got it to pass without failure right now, so perhaps better times have arrived.
* Pass `--all-features` at docs.rs to match our CI and reduce the maintenance burden of manually syncing the features list.
* Enable the `doc_auto_cfg` feature for docs.rs which will show a little tip next to feature gated functionality informing of the crate feature flag.