### PR TITLE
gradient: Add hue direction and interpolation color space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release has an [MSRV] of 1.82.
 - `Image` now stores the alpha as an `f32` ([#65][] by [@waywardmonkeys][])
 - Use `color` crate. See below for details ([#63][] by [@waywardmonkeys][])
 - `Gradient`, `Image`, `Brush` now have `with_alpha` and `Gradient` also gets a `multiply_alpha` ([#67][] by [@waywardmonkeys][])
+- `Gradient` now tracks a hue direction and interpolation color space ([#71][] by [@waywardmonkeys][])
 
 ### Color Changes
 
@@ -78,6 +79,7 @@ This release has an [MSRV] of 1.70.
 [#63]: https://github.com/linebender/peniko/pull/63
 [#65]: https://github.com/linebender/peniko/pull/65
 [#67]: https://github.com/linebender/peniko/pull/67
+[#71]: https://github.com/linebender/peniko/pull/71
 
 [@DJMcNab]: https://github.com/DJMcNab
 [@ratmice]: https://github.com/ratmice

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "color"
 version = "0.1.0"
-source = "git+https://github.com/linebender/color.git?rev=a4fa61aff6c3f292b729dc409e7832e5f0166e4a#a4fa61aff6c3f292b729dc409e7832e5f0166e4a"
+source = "git+https://github.com/linebender/color.git?rev=2782bd6cb05c5f82a157c8f7f0ebe7a47760a2c0#2782bd6cb05c5f82a157c8f7f0ebe7a47760a2c0"
 dependencies = [
  "libm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ smallvec = "1.13.2"
 
 [dependencies.color]
 git = "https://github.com/linebender/color.git"
-rev = "a4fa61aff6c3f292b729dc409e7832e5f0166e4a"
+rev = "2782bd6cb05c5f82a157c8f7f0ebe7a47760a2c0"
 version = "0.1.0"
 default-features = false
 

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -3,11 +3,16 @@
 
 use super::Extend;
 
-use color::{AlphaColor, ColorSpace, DynamicColor, OpaqueColor};
+use color::{AlphaColor, ColorSpace, ColorSpaceTag, DynamicColor, HueDirection, OpaqueColor};
 use kurbo::Point;
 use smallvec::SmallVec;
 
 use core::hash::{Hash, Hasher};
+
+/// The default for `Gradient::interpolation_cs`.
+// This is intentionally not `pub` and is here in case we change it
+// in the future.
+const DEFAULT_GRADIENT_COLOR_SPACE: ColorSpaceTag = ColorSpaceTag::Srgb;
 
 /// Offset and color of a transition point in a [gradient](Gradient).
 #[derive(Copy, Clone, Debug)]
@@ -141,6 +146,18 @@ pub struct Gradient {
     pub kind: GradientKind,
     /// Extend mode.
     pub extend: Extend,
+    /// The color space to be used for interpolation.
+    ///
+    /// The colors in the color stops will be converted to this color space.
+    ///
+    /// This defaults to [sRGB](ColorSpaceTag::Srgb).
+    pub interpolation_cs: ColorSpaceTag,
+    /// When interpolating within a cylindrical color space, the direction for the hue.
+    ///
+    /// This is interpreted as described in [CSS Color Module Level 4 § 12.4].
+    ///
+    /// [CSS Color Module Level 4 § 12.4]: https://drafts.csswg.org/css-color/#hue-interpolation
+    pub hue_direction: HueDirection,
     /// Color stop collection.
     pub stops: ColorStops,
 }
@@ -153,6 +170,8 @@ impl Default for Gradient {
                 end: Point::default(),
             },
             extend: Default::default(),
+            interpolation_cs: DEFAULT_GRADIENT_COLOR_SPACE,
+            hue_direction: Default::default(),
             stops: Default::default(),
         }
     }
@@ -167,6 +186,8 @@ impl Gradient {
                 end: end.into(),
             },
             extend: Default::default(),
+            interpolation_cs: DEFAULT_GRADIENT_COLOR_SPACE,
+            hue_direction: Default::default(),
             stops: Default::default(),
         }
     }
@@ -182,6 +203,8 @@ impl Gradient {
                 end_radius: radius,
             },
             extend: Default::default(),
+            interpolation_cs: DEFAULT_GRADIENT_COLOR_SPACE,
+            hue_direction: Default::default(),
             stops: Default::default(),
         }
     }
@@ -201,6 +224,8 @@ impl Gradient {
                 end_radius,
             },
             extend: Default::default(),
+            interpolation_cs: DEFAULT_GRADIENT_COLOR_SPACE,
+            hue_direction: Default::default(),
             stops: Default::default(),
         }
     }
@@ -215,6 +240,8 @@ impl Gradient {
                 end_angle,
             },
             extend: Default::default(),
+            interpolation_cs: DEFAULT_GRADIENT_COLOR_SPACE,
+            hue_direction: Default::default(),
             stops: Default::default(),
         }
     }
@@ -223,6 +250,20 @@ impl Gradient {
     #[must_use]
     pub fn with_extend(mut self, mode: Extend) -> Self {
         self.extend = mode;
+        self
+    }
+
+    /// Builder method for setting the interpolation color space.
+    #[must_use]
+    pub fn with_interpolation_cs(mut self, interpolation_cs: ColorSpaceTag) -> Self {
+        self.interpolation_cs = interpolation_cs;
+        self
+    }
+
+    /// Builder method for setting the hue direction when interpolating within a cylindrical color space.
+    #[must_use]
+    pub fn with_hue_direction(mut self, hue_direction: HueDirection) -> Self {
+        self.hue_direction = hue_direction;
         self
     }
 


### PR DESCRIPTION
CSS Color Module Level 4 adds these to the gradient definition and defines the behavior that they should exhibit.

These are implemented in the Color crate but not yet in Vello.