### PR TITLE
Add x/y extend modes and quality hint to images

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -7,12 +7,12 @@ use super::{Blob, Extend};
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
-pub enum Format {
+pub enum ImageFormat {
     /// 32-bit RGBA with 8-bit channels.
     Rgba8,
 }
 
-impl Format {
+impl ImageFormat {
     /// Returns the required size in bytes for an image in this format
     /// of the given dimensions.
     ///
@@ -27,6 +27,25 @@ impl Format {
     }
 }
 
+/// Defines the desired quality for sampling an [image](Image).
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ImageQuality {
+    /// Lowest quality with best performance characteristics.
+    ///
+    /// This is typically nearest neighbor sampling.
+    Low,
+    /// Medium quality with reasonable performance characteristics.
+    ///
+    /// This is typically bilinear sampling.
+    #[default]
+    Medium,
+    /// Highest quality with worst performance characteristics.
+    ///
+    /// This is typically bicubic sampling.
+    High,
+}
+
 /// Owned shareable image resource.
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -34,36 +53,68 @@ pub struct Image {
     /// Blob containing the image data.
     pub data: Blob<u8>,
     /// Pixel format of the image.
-    pub format: Format,
+    pub format: ImageFormat,
     /// Width of the image.
     pub width: u32,
     /// Height of the image.
     pub height: u32,
-    /// Extend mode.
-    pub extend: Extend,
+    /// Extend mode in the horizontal direction.
+    pub x_extend: Extend,
+    /// Extend mode in the vertical direction.
+    pub y_extend: Extend,
+    /// Hint for desired rendering quality.
+    pub quality: ImageQuality,
     /// An additional alpha multiplier to use with the image.
     pub alpha: f32,
 }
 
 impl Image {
-    /// Creates a new image with the given data, [format](Format) and dimensions.
+    /// Creates a new image with the given data, [format](ImageFormat) and dimensions.
     #[must_use]
-    pub fn new(data: Blob<u8>, format: Format, width: u32, height: u32) -> Self {
+    pub fn new(data: Blob<u8>, format: ImageFormat, width: u32, height: u32) -> Self {
         Self {
             data,
             format,
             width,
             height,
-            extend: Extend::Pad,
+            x_extend: Extend::Pad,
+            y_extend: Extend::Pad,
+            quality: ImageQuality::Medium,
             // Opaque
             alpha: 1.,
         }
     }
 
-    /// Builder method for setting the image [extend mode](Extend).
+    /// Builder method for setting the image [extend mode](Extend) in both
+    /// directions.
     #[must_use]
     pub fn with_extend(mut self, mode: Extend) -> Self {
-        self.extend = mode;
+        self.x_extend = mode;
+        self.y_extend = mode;
+        self
+    }
+
+    /// Builder method for setting the image [extend mode](Extend) in the
+    /// horizontal direction.
+    #[must_use]
+    pub fn with_x_extend(mut self, mode: Extend) -> Self {
+        self.x_extend = mode;
+        self
+    }
+
+    /// Builder method for setting the image [extend mode](Extend) in the
+    /// vertical direction.
+    #[must_use]
+    pub fn with_y_extend(mut self, mode: Extend) -> Self {
+        self.y_extend = mode;
+        self
+    }
+
+    /// Builder method for setting a hint for the desired image [quality](ImageQuality)
+    /// when rendering.
+    #[must_use]
+    pub fn with_quality(mut self, quality: ImageQuality) -> Self {
+        self.quality = quality;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use blob::{Blob, WeakBlob};
 pub use brush::{Brush, BrushRef, Extend};
 pub use font::Font;
 pub use gradient::{ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind};
-pub use image::{Format, Image};
+pub use image::{Image, ImageFormat, ImageQuality};
 pub use style::{Fill, Style, StyleRef};
 
 /// A convenient alias for the color type used for [`Brush`].


### PR DESCRIPTION
Changes `Image` to support separate extend modes for each dimension.

Also adds an `ImageQuality` enum to allow the user to specify a hint for rendering. I choose low/medium/high variants rather than specific filters so that we're not making a specific commitment to any set.

Finally, renames `Format` to `ImageFormat` for consistency.