### PR TITLE
`ColorStopsSource` can operate on `ColorStops`

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -325,17 +325,17 @@ impl Gradient {
 
 /// Trait for types that represent a source of color stops.
 pub trait ColorStopsSource {
-    /// Append the stops represented within `self` into `vec`.
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>);
+    /// Append the stops represented within `self` into `stops`.
+    fn collect_stops(&self, stops: &mut ColorStops);
 }
 
 impl<T> ColorStopsSource for &'_ [T]
 where
     T: Into<ColorStop> + Copy,
 {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
+    fn collect_stops(&self, stops: &mut ColorStops) {
         for &stop in *self {
-            vec.push(stop.into());
+            stops.push(stop.into());
         }
     }
 }
@@ -344,18 +344,18 @@ impl<T, const N: usize> ColorStopsSource for [T; N]
 where
     T: Into<ColorStop> + Copy,
 {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
+    fn collect_stops(&self, stops: &mut ColorStops) {
         for stop in *self {
-            vec.push(stop.into());
+            stops.push(stop.into());
         }
     }
 }
 
 impl<CS: ColorSpace> ColorStopsSource for &'_ [AlphaColor<CS>] {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
+    fn collect_stops(&self, stops: &mut ColorStops) {
         if !self.is_empty() {
             let denom = (self.len() - 1).max(1) as f32;
-            vec.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
+            stops.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
                 offset: (i as f32) / denom,
                 color: DynamicColor::from_alpha_color(*c),
             }));
@@ -364,10 +364,10 @@ impl<CS: ColorSpace> ColorStopsSource for &'_ [AlphaColor<CS>] {
 }
 
 impl ColorStopsSource for &'_ [DynamicColor] {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
+    fn collect_stops(&self, stops: &mut ColorStops) {
         if !self.is_empty() {
             let denom = (self.len() - 1).max(1) as f32;
-            vec.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
+            stops.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
                 offset: (i as f32) / denom,
                 color: (*c),
             }));
@@ -376,10 +376,10 @@ impl ColorStopsSource for &'_ [DynamicColor] {
 }
 
 impl<CS: ColorSpace> ColorStopsSource for &'_ [OpaqueColor<CS>] {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
+    fn collect_stops(&self, stops: &mut ColorStops) {
         if !self.is_empty() {
             let denom = (self.len() - 1).max(1) as f32;
-            vec.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
+            stops.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
                 offset: (i as f32) / denom,
                 color: DynamicColor::from_alpha_color((*c).with_alpha(1.)),
             }));
@@ -388,18 +388,18 @@ impl<CS: ColorSpace> ColorStopsSource for &'_ [OpaqueColor<CS>] {
 }
 
 impl<const N: usize, CS: ColorSpace> ColorStopsSource for [AlphaColor<CS>; N] {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
-        (&self[..]).collect_stops(vec);
+    fn collect_stops(&self, stops: &mut ColorStops) {
+        (&self[..]).collect_stops(stops);
     }
 }
 impl<const N: usize> ColorStopsSource for [DynamicColor; N] {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
-        (&self[..]).collect_stops(vec);
+    fn collect_stops(&self, stops: &mut ColorStops) {
+        (&self[..]).collect_stops(stops);
     }
 }
 impl<const N: usize, CS: ColorSpace> ColorStopsSource for [OpaqueColor<CS>; N] {
-    fn collect_stops(&self, vec: &mut SmallVec<[ColorStop; 4]>) {
-        (&self[..]).collect_stops(vec);
+    fn collect_stops(&self, stops: &mut ColorStops) {
+        (&self[..]).collect_stops(stops);
     }
 }
 


### PR DESCRIPTION
Rather than operating on the inner collection type (a `SmallVec`), operate on the `ColorStops` wrapper type. This makes it easier to externally implement this type as is done in Vello for converting from Skrifa color stops to the Peniko versions.