### PR TITLE
`ColorStopsSource::collect_stops` now consumes `self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release has an [MSRV] of 1.82.
 
 - `Image` now stores the alpha as an `f32` ([#65][] by [@waywardmonkeys][])
 - Use `color` crate. See below for details ([#63][] by [@waywardmonkeys][])
+- `ColorStopsSource::collect_stops` now consumes `self` ([#87][] by [@waywardmonkeys][])
 
 ### Removed
 
@@ -93,6 +94,7 @@ This release has an [MSRV] of 1.70.
 [#72]: https://github.com/linebender/peniko/pull/72
 [#77]: https://github.com/linebender/peniko/pull/77
 [#82]: https://github.com/linebender/peniko/pull/82
+[#87]: https://github.com/linebender/peniko/pull/87
 
 [@dfrg]: https://github.com/dfrg
 [@DJMcNab]: https://github.com/DJMcNab

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -332,15 +332,15 @@ impl Gradient {
 /// Trait for types that represent a source of color stops.
 pub trait ColorStopsSource {
     /// Append the stops represented within `self` into `stops`.
-    fn collect_stops(&self, stops: &mut ColorStops);
+    fn collect_stops(self, stops: &mut ColorStops);
 }
 
 impl<T> ColorStopsSource for &'_ [T]
 where
     T: Into<ColorStop> + Copy,
 {
-    fn collect_stops(&self, stops: &mut ColorStops) {
-        for &stop in *self {
+    fn collect_stops(self, stops: &mut ColorStops) {
+        for &stop in self {
             stops.push(stop.into());
         }
     }
@@ -350,15 +350,15 @@ impl<T, const N: usize> ColorStopsSource for [T; N]
 where
     T: Into<ColorStop> + Copy,
 {
-    fn collect_stops(&self, stops: &mut ColorStops) {
-        for stop in *self {
+    fn collect_stops(self, stops: &mut ColorStops) {
+        for &stop in &self {
             stops.push(stop.into());
         }
     }
 }
 
 impl<CS: ColorSpace> ColorStopsSource for &'_ [AlphaColor<CS>] {
-    fn collect_stops(&self, stops: &mut ColorStops) {
+    fn collect_stops(self, stops: &mut ColorStops) {
         if !self.is_empty() {
             let denom = (self.len() - 1).max(1) as f32;
             stops.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
@@ -370,7 +370,7 @@ impl<CS: ColorSpace> ColorStopsSource for &'_ [AlphaColor<CS>] {
 }
 
 impl ColorStopsSource for &'_ [DynamicColor] {
-    fn collect_stops(&self, stops: &mut ColorStops) {
+    fn collect_stops(self, stops: &mut ColorStops) {
         if !self.is_empty() {
             let denom = (self.len() - 1).max(1) as f32;
             stops.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
@@ -382,7 +382,7 @@ impl ColorStopsSource for &'_ [DynamicColor] {
 }
 
 impl<CS: ColorSpace> ColorStopsSource for &'_ [OpaqueColor<CS>] {
-    fn collect_stops(&self, stops: &mut ColorStops) {
+    fn collect_stops(self, stops: &mut ColorStops) {
         if !self.is_empty() {
             let denom = (self.len() - 1).max(1) as f32;
             stops.extend(self.iter().enumerate().map(|(i, c)| ColorStop {
@@ -394,17 +394,17 @@ impl<CS: ColorSpace> ColorStopsSource for &'_ [OpaqueColor<CS>] {
 }
 
 impl<const N: usize, CS: ColorSpace> ColorStopsSource for [AlphaColor<CS>; N] {
-    fn collect_stops(&self, stops: &mut ColorStops) {
+    fn collect_stops(self, stops: &mut ColorStops) {
         (&self[..]).collect_stops(stops);
     }
 }
 impl<const N: usize> ColorStopsSource for [DynamicColor; N] {
-    fn collect_stops(&self, stops: &mut ColorStops) {
+    fn collect_stops(self, stops: &mut ColorStops) {
         (&self[..]).collect_stops(stops);
     }
 }
 impl<const N: usize, CS: ColorSpace> ColorStopsSource for [OpaqueColor<CS>; N] {
-    fn collect_stops(&self, stops: &mut ColorStops) {
+    fn collect_stops(self, stops: &mut ColorStops) {
         (&self[..]).collect_stops(stops);
     }
 }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -348,10 +348,10 @@ where
 
 impl<T, const N: usize> ColorStopsSource for [T; N]
 where
-    T: Into<ColorStop> + Copy,
+    T: Into<ColorStop>,
 {
     fn collect_stops(self, stops: &mut ColorStops) {
-        for &stop in &self {
+        for stop in self.into_iter() {
             stops.push(stop.into());
         }
     }


### PR DESCRIPTION
This addresses a warning from pedantic lints about stops being passed by `Gradient::with_stops` by value, but not consuming it.