### PR TITLE
Remove Kurbo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Linebender Zulip, #kurbo channel](https://img.shields.io/badge/Linebender-%23kurbo-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/260979-kurbo)
 [![dependency status](https://deps.rs/repo/github/linebender/peniko/status.svg)](https://deps.rs/repo/github/linebender/peniko)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
-[![kurbo version 0.11.1](https://img.shields.io/badge/kurbo-v0.11.1-orange.svg)](https://crates.io/crates/kurbo)
 [![Build status](https://github.com/linebender/peniko/workflows/CI/badge.svg)](https://github.com/linebender/peniko/actions)
 [![Crates.io](https://img.shields.io/crates/v/peniko.svg)](https://crates.io/crates/peniko)
 [![Docs](https://docs.rs/peniko/badge.svg)](https://docs.rs/peniko)


### PR DESCRIPTION
This isn’t something that we do in our other crates and doesn’t really add much (any?) value.

Fixes #93.