### PR TITLE
Update dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "color"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010263546cea9f9f8385a5b7aad534b9e6448e62a0d3bf9da29d583308dd11bb"
+checksum = "7ae467d04a8a8aea5d9a49018a6ade2e4221d92968e8ce55a48c0b1164e5f698"
 dependencies = [
  "bytemuck",
  "libm",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "mint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ optional = true
 default-features = false
 
 [dependencies.color]
-version = "0.3.0"
+version = "0.3.1"
 default-features = false
 
 [dependencies.serde]


### PR DESCRIPTION
This is a result of:

```
cargo update --ignore-rust-version
cargo upgrade --ignore-rust-version
```

Most notably this gets us `color` 0.3.1 which fixes nightly compilation.