### PR TITLE
Add `Compose::PlusDarker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release has an [MSRV] of 1.82.
 
 ### Changed
 
+- Breaking change: Added `PlusDarker` variant to `Compose` ([#112][] by [@sagudev][])
 - Breaking change: `Image` has been renamed to `ImageBrush`, which now consists of an `ImageData` and an `ImageSampler`. ([#117][], [#123][] by [@nicoburns][], [@DJMcNab][])
 - Breaking change: `Font` has been renamed to `FontData` to match `ImageData`. ([#126][] by [@nicoburns][])
 - Breaking change: the angle directions of `SweepGradientPosition` are now described to be clockwise in a Y-down coordinate system, as is common in computer graphics.
@@ -152,6 +153,7 @@ This release has an [MSRV] of 1.70.
 [#95]: https://github.com/linebender/peniko/pull/95
 [#103]: https://github.com/linebender/peniko/pull/103
 [#104]: https://github.com/linebender/peniko/pull/104
+[#112]: https://github.com/linebender/peniko/pull/112
 [#114]: https://github.com/linebender/peniko/pull/114
 [#115]: https://github.com/linebender/peniko/pull/115
 [#117]: https://github.com/linebender/peniko/pull/117

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -91,6 +91,12 @@ pub enum Compose {
     /// Allows two elements to cross fade by changing their opacities from 0 to 1 on one
     /// element and 1 to 0 on the other element.
     PlusLighter = 13,
+    /// The behavior of this mode is currently not exactly defined,
+    /// as spec discussions are still ongoing [w3c/fxtf-drafts#447],
+    /// but it's present here to prevent future breaking changes.
+    ///
+    /// [w3c/fxtf-drafts#447](https://github.com/w3c/fxtf-drafts/issues/447)
+    PlusDarker = 14,
     // NOTICE: If a new value is added, be sure to modify `MAX_VALUE` in the bytemuck impl.
 }
 

--- a/src/impl_bytemuck.rs
+++ b/src/impl_bytemuck.rs
@@ -27,7 +27,7 @@ unsafe impl bytemuck::checked::CheckedBitPattern for Compose {
 unsafe impl bytemuck::Contiguous for Compose {
     type Int = u8;
     const MIN_VALUE: u8 = Self::Clear as u8;
-    const MAX_VALUE: u8 = Self::PlusLighter as u8;
+    const MAX_VALUE: u8 = Self::PlusDarker as u8;
 }
 
 // Safety: The enum is `repr(u8)` and has only fieldless variants.
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn contiguous() {
-        let compose1 = Compose::PlusLighter;
+        let compose1 = Compose::PlusDarker;
         let compose2 = Compose::from_integer(compose1.into_integer());
         assert_eq!(Some(compose1), compose2);
 


### PR DESCRIPTION
This is the only composite/blending mode that we are missing per spec: https://drafts.fxtf.org/compositing/#compositemode

This is a breaking change.