### PR TITLE
Add mask-from-luminance 

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -49,6 +49,9 @@ pub enum Mix {
     /// Creates a color with the luminosity of the source color and the hue and saturation of the
     /// backdrop color. This produces an inverse effect to that of the `Color` mode.
     Luminosity = 15,
+    /// `LuminanceClip` is the same as `Clip`, but is based on Luminance instead of alpha, as in
+    /// SVG mask-type
+    LuminanceClip = 64,
     /// `Clip` is the same as `Normal`, but the latter always creates an isolated blend group and the
     /// former can optimize that out.
     Clip = 128,


### PR DESCRIPTION
SVG has support for Luminance based masking but vello doesn't support luminance based masking. Adding the enum in peniko would allow for adding the feature as vello doesn't support pre-processing.
https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/mask-type