### PR TITLE
Add `PositionedGlyph` and `NormalizedCoord` types

### DIFF
--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -1,0 +1,16 @@
+// Copyright 2022 the Peniko Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Normalized variation coordinate in 2.14 fixed point format.
+pub type NormalizedCoord = i16;
+
+/// A glyph positioned in 2D space
+#[derive(Copy, Clone, Debug)]
+pub struct PositionedGlyph {
+    /// The ID of the glyph within it's font
+    pub id: u32,
+    /// The x position of the glyph
+    pub x: f32,
+    /// The y position of the glyph
+    pub y: f32,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod blend;
 mod blob;
 mod brush;
 mod font;
+mod glyph;
 mod gradient;
 mod image;
 mod style;
@@ -47,6 +48,7 @@ pub use blend::{BlendMode, Compose, Mix};
 pub use blob::{Blob, WeakBlob};
 pub use brush::{Brush, BrushRef, Extend};
 pub use font::Font;
+pub use glyph::{NormalizedCoord, PositionedGlyph};
 pub use gradient::{
     ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind, LinearGradientPosition,
     RadialGradientPosition, SweepGradientPosition,


### PR DESCRIPTION
These types exist in all of `vello`, `vello_common` and `anyrender`, all of which depend on `peniko` which contains most of their other API types. This "upstreams" these types into `peniko`.

Similar types also exist in swash/skrifa/parley, but it is *not* intended that those crates would use this version of the type.