### PR TITLE
Create structs for each gradient kind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,10 @@ pub use blend::{BlendMode, Compose, Mix};
 pub use blob::{Blob, WeakBlob};
 pub use brush::{Brush, BrushRef, Extend};
 pub use font::Font;
-pub use gradient::{ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind};
+pub use gradient::{
+    ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind, LinearGradientPosition,
+    RadialGradientPosition, SweepGradientPosition,
+};
 pub use image::{Image, ImageFormat, ImageQuality};
 pub use style::{Fill, Style, StyleRef};
 


### PR DESCRIPTION
Struct-like enums are difficult to work with as you can't take a reference to or pass around the values for an individual kind. This PR:
- Creates structs for each variant and makes each enum variant wraps a struct.
- Add some `From` impls and constructors that are possible now we have dedicated types for each gradient kind.