### PR TITLE
Add `ImageFormat::Bgra8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release has an [MSRV] of 1.82.
 ### Added
 
 - `Style` now impl `PartialEq`. ([#114][] by [@liferooter][])
+- Add `Bgra8` variant to `ImageFormat`. ([#120][] by [@sagudev][])
 
 ## [0.4.0][] (2025-04-30)
 
@@ -135,11 +136,13 @@ This release has an [MSRV] of 1.70.
 [#103]: https://github.com/linebender/peniko/pull/103
 [#104]: https://github.com/linebender/peniko/pull/104
 [#114]: https://github.com/linebender/peniko/pull/114
+[#120]: https://github.com/linebender/peniko/pull/120
 
 [@dfrg]: https://github.com/dfrg
 [@DJMcNab]: https://github.com/DJMcNab
 [@liferooter]: https://github.com/liferooter
 [@ratmice]: https://github.com/ratmice
+[@sagudev]: https://github.com/sagudev
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
 [Unreleased]: https://github.com/linebender/peniko/compare/v0.4.0...HEAD

--- a/src/image.rs
+++ b/src/image.rs
@@ -11,6 +11,8 @@ use super::{Blob, Extend};
 pub enum ImageFormat {
     /// 32-bit RGBA with 8-bit channels.
     Rgba8 = 0,
+    /// 32-bit BGRA with 8-bit channels.
+    Bgra8 = 1,
     // NOTICE: If a new value is added, be sure to update the bytemuck CheckedBitPattern impl.
 }
 
@@ -22,7 +24,7 @@ impl ImageFormat {
     #[must_use]
     pub fn size_in_bytes(self, width: u32, height: u32) -> Option<usize> {
         match self {
-            Self::Rgba8 => 4_usize
+            Self::Rgba8 | Self::Bgra8 => 4_usize
                 .checked_mul(width as usize)
                 .and_then(|x| x.checked_mul(height as usize)),
         }

--- a/src/impl_bytemuck.rs
+++ b/src/impl_bytemuck.rs
@@ -91,10 +91,6 @@ unsafe impl bytemuck::checked::CheckedBitPattern for ImageFormat {
     type Bits = u8;
 
     fn is_valid_bit_pattern(bits: &u8) -> bool {
-        #![expect(
-            clippy::absurd_extreme_comparisons,
-            reason = "There is only one value."
-        )]
         use bytemuck::Contiguous;
         // Don't need to compare against MIN_VALUE as this is u8 and 0 is the MIN_VALUE.
         *bits <= Self::MAX_VALUE
@@ -106,7 +102,7 @@ unsafe impl bytemuck::checked::CheckedBitPattern for ImageFormat {
 unsafe impl bytemuck::Contiguous for ImageFormat {
     type Int = u8;
     const MIN_VALUE: u8 = Self::Rgba8 as u8;
-    const MAX_VALUE: u8 = Self::Rgba8 as u8;
+    const MAX_VALUE: u8 = Self::Bgra8 as u8;
 }
 
 // Safety: The enum is `repr(u8)` and has only fieldless variants.
@@ -173,6 +169,10 @@ mod tests {
         assert_eq!(
             Ok(&ImageFormat::Rgba8),
             try_from_bytes::<ImageFormat>(valid_zero)
+        );
+        assert_eq!(
+            Ok(&ImageFormat::Bgra8),
+            try_from_bytes::<ImageFormat>(valid_one)
         );
         assert!(try_from_bytes::<ImageFormat>(invalid).is_err());
 
@@ -283,10 +283,6 @@ mod tests {
     /// Tests that the [`Contiguous`] impl for [`ImageFormat`] is not trivially incorrect.
     const _: () = {
         let mut value = 0;
-        #[expect(
-            clippy::absurd_extreme_comparisons,
-            reason = "There is only one value."
-        )]
         while value <= ImageFormat::MAX_VALUE {
             // Safety: In a const context, therefore if this makes an invalid ImageFormat, that will be detected.
             let it: ImageFormat = unsafe { ptr::read((&raw const value).cast()) };


### PR DESCRIPTION
~~Vello can handle this easily with `textureSample` which automagically makes it RGBA.~~
Actually vello uses `textureLoad` and atlas texture, so we would need to implement this as in vello_cpu, preferably with swaping on image cmd (this should be just bgra vs rgba swizle).