### PR TITLE
Rename `ImageRenderParams` to `ImageSampler`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -64,10 +64,10 @@ pub struct ImageData {
     pub height: u32,
 }
 
-/// Parameters which specify how to render an image.
+/// Parameters which specify how to sample an image during rendering.
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ImageRenderParams {
+pub struct ImageSampler {
     /// Extend mode in the horizontal direction.
     pub x_extend: Extend,
     /// Extend mode in the vertical direction.
@@ -78,7 +78,7 @@ pub struct ImageRenderParams {
     pub alpha: f32,
 }
 
-impl Default for ImageRenderParams {
+impl Default for ImageSampler {
     fn default() -> Self {
         Self {
             x_extend: Extend::Pad,
@@ -89,8 +89,8 @@ impl Default for ImageRenderParams {
     }
 }
 
-impl ImageRenderParams {
-    /// Creates a new `ImageRenderParams` with default values
+impl ImageSampler {
+    /// Creates a new `ImageSampler` with default values
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -163,17 +163,17 @@ impl ImageRenderParams {
 pub struct ImageBrush {
     /// The image to render.
     pub image: ImageData,
-    /// Parameters which specify how to render the image.
-    pub params: ImageRenderParams,
+    /// Parameters which specify how to sample from the image during rendering.
+    pub sampler: ImageSampler,
 }
 
 impl ImageBrush {
-    /// Creates a new `ImageBrush` for the specified `ImageData` with default `ImageRenderParams`.
+    /// Creates a new `ImageBrush` for the specified `ImageData` with default `ImageSampler`.
     #[must_use]
     pub fn new(image: ImageData) -> Self {
         Self {
             image,
-            params: ImageRenderParams::default(),
+            sampler: ImageSampler::default(),
         }
     }
 
@@ -182,7 +182,7 @@ impl ImageBrush {
     pub fn as_ref(&self) -> ImageBrushRef<'_> {
         ImageBrushRef {
             image: &self.image,
-            params: self.params,
+            sampler: self.sampler,
         }
     }
 
@@ -190,8 +190,8 @@ impl ImageBrush {
     /// directions.
     #[must_use]
     pub fn with_extend(mut self, mode: Extend) -> Self {
-        self.params.x_extend = mode;
-        self.params.y_extend = mode;
+        self.sampler.x_extend = mode;
+        self.sampler.y_extend = mode;
         self
     }
 
@@ -199,7 +199,7 @@ impl ImageBrush {
     /// horizontal direction.
     #[must_use]
     pub fn with_x_extend(mut self, mode: Extend) -> Self {
-        self.params.x_extend = mode;
+        self.sampler.x_extend = mode;
         self
     }
 
@@ -207,7 +207,7 @@ impl ImageBrush {
     /// vertical direction.
     #[must_use]
     pub fn with_y_extend(mut self, mode: Extend) -> Self {
-        self.params.y_extend = mode;
+        self.sampler.y_extend = mode;
         self
     }
 
@@ -215,7 +215,7 @@ impl ImageBrush {
     /// when rendering.
     #[must_use]
     pub fn with_quality(mut self, quality: ImageQuality) -> Self {
-        self.params.quality = quality;
+        self.sampler.quality = quality;
         self
     }
 
@@ -227,7 +227,7 @@ impl ImageBrush {
             alpha.is_finite() && alpha >= 0.0,
             "A non-finite or negative alpha ({alpha}) is meaningless."
         );
-        self.params.alpha = alpha;
+        self.sampler.alpha = alpha;
         self
     }
 
@@ -240,7 +240,7 @@ impl ImageBrush {
             alpha.is_finite() && alpha >= 0.0,
             "A non-finite or negative alpha ({alpha}) is meaningless."
         );
-        self.params.alpha *= alpha;
+        self.sampler.alpha *= alpha;
         self
     }
 }
@@ -250,8 +250,8 @@ impl ImageBrush {
 pub struct ImageBrushRef<'a> {
     /// The image to render.
     pub image: &'a ImageData,
-    /// Parameters which specify how to render the image.
-    pub params: ImageRenderParams,
+    /// Parameters which specify how to sample from the image during rendering.
+    pub sampler: ImageSampler,
 }
 
 impl ImageBrushRef<'_> {
@@ -260,7 +260,7 @@ impl ImageBrushRef<'_> {
     pub fn new<'a>(image: &'a ImageData) -> ImageBrushRef<'a> {
         ImageBrushRef {
             image,
-            params: ImageRenderParams::default(),
+            sampler: ImageSampler::default(),
         }
     }
 
@@ -269,7 +269,7 @@ impl ImageBrushRef<'_> {
     pub fn to_owned(&self) -> ImageBrush {
         ImageBrush {
             image: (*self.image).clone(),
-            params: self.params,
+            sampler: self.sampler,
         }
     }
 
@@ -277,8 +277,8 @@ impl ImageBrushRef<'_> {
     /// directions.
     #[must_use]
     pub fn with_extend(mut self, mode: Extend) -> Self {
-        self.params.x_extend = mode;
-        self.params.y_extend = mode;
+        self.sampler.x_extend = mode;
+        self.sampler.y_extend = mode;
         self
     }
 
@@ -286,7 +286,7 @@ impl ImageBrushRef<'_> {
     /// horizontal direction.
     #[must_use]
     pub fn with_x_extend(mut self, mode: Extend) -> Self {
-        self.params.x_extend = mode;
+        self.sampler.x_extend = mode;
         self
     }
 
@@ -294,7 +294,7 @@ impl ImageBrushRef<'_> {
     /// vertical direction.
     #[must_use]
     pub fn with_y_extend(mut self, mode: Extend) -> Self {
-        self.params.y_extend = mode;
+        self.sampler.y_extend = mode;
         self
     }
 
@@ -302,7 +302,7 @@ impl ImageBrushRef<'_> {
     /// when rendering.
     #[must_use]
     pub fn with_quality(mut self, quality: ImageQuality) -> Self {
-        self.params.quality = quality;
+        self.sampler.quality = quality;
         self
     }
 
@@ -314,7 +314,7 @@ impl ImageBrushRef<'_> {
             alpha.is_finite() && alpha >= 0.0,
             "A non-finite or negative alpha ({alpha}) is meaningless."
         );
-        self.params.alpha = alpha;
+        self.sampler.alpha = alpha;
         self
     }
 
@@ -327,7 +327,7 @@ impl ImageBrushRef<'_> {
             alpha.is_finite() && alpha >= 0.0,
             "A non-finite or negative alpha ({alpha}) is meaningless."
         );
-        self.params.alpha *= alpha;
+        self.sampler.alpha *= alpha;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,7 @@ pub use gradient::{
     ColorStop, ColorStops, ColorStopsSource, Gradient, GradientKind, LinearGradientPosition,
     RadialGradientPosition, SweepGradientPosition,
 };
-pub use image::{
-    ImageBrush, ImageBrushRef, ImageData, ImageFormat, ImageQuality, ImageRenderParams,
-};
+pub use image::{ImageBrush, ImageBrushRef, ImageData, ImageFormat, ImageQuality, ImageSampler};
 pub use style::{Fill, Style, StyleRef};
 
 /// A convenient alias for the color type used for [`Brush`].


### PR DESCRIPTION
See discussion in https://github.com/linebender/peniko/pull/117#discussion_r2251114601

I won't merge this until at least Renderer Office Hours tomorrow.