### PR TITLE
Refactor Brush to use generic types for image and gradient data

### DIFF
--- a/src/brush.rs
+++ b/src/brush.rs
@@ -63,8 +63,8 @@ impl<I> From<Gradient> for Brush<I, Gradient> {
     }
 }
 
-impl<G> From<ImageBrush> for Brush<ImageBrush, G> {
-    fn from(value: ImageBrush) -> Self {
+impl<G, D> From<ImageBrush<D>> for Brush<ImageBrush<D>, G> {
+    fn from(value: ImageBrush<D>) -> Self {
         Self::Image(value)
     }
 }
@@ -132,12 +132,6 @@ impl BrushRef<'_> {
 impl<'a> From<&'a Gradient> for BrushRef<'a> {
     fn from(gradient: &'a Gradient) -> Self {
         Self::Gradient(gradient)
-    }
-}
-
-impl<'a> From<ImageBrushRef<'a>> for BrushRef<'a> {
-    fn from(image: ImageBrushRef<'a>) -> Self {
-        Self::Image(image)
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/linebender/peniko/pull/133#pullrequestreview-3223338398 we can also generalize `Brush` over image data and gradient. This makes `BrushRef<'a> = Brush<ImageBrushRef<'a>, &'a Gradient>` which allows to share more From impls, most notably various color implementations (even owned version can now support conversion from &color because color is copy anyway).