### PR TITLE
Exclude `.taplo.toml` as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files.
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 rust-version = "1.82"
-exclude = [".github", ".clippy.toml", ".gitignore", ".typos.toml"]
+exclude = [".github", ".clippy.toml", ".gitignore", ".typos.toml", ".taplo.toml"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Caught as part of final release checks for v0.4.1. I'm not going to block v0.4.1 on this, though