### PR TITLE
Deprecate `Mix::Clip` and change the default blend mode

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -84,8 +84,13 @@ pub enum Mix {
     ///
     /// ![](https://www.w3.org/TR/compositing-1/examples/luminosity.png)
     Luminosity = 15,
-    /// `Clip` is the same as `Normal`, but the latter always creates an isolated blend group and the
-    /// former can optimize that out.
+    /// Clip was similar to [`Normal`], but was optimised for clipping (by avoiding
+    /// blending in areas where there was no clip path).
+    ///
+    /// This optimisation is however unrelated to mixing, and so is no longer indicated with this enum.
+    ///
+    /// If you were using this with Vello, you should use `push_clip_layer` function instead.
+    #[deprecated(note = "Use `push_clip_layer` instead.", since = "0.5.0")]
     Clip = 128,
     // NOTICE: If a new value is added, be sure to update the bytemuck CheckedBitPattern impl.
 }

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -183,7 +183,7 @@ impl BlendMode {
 impl Default for BlendMode {
     fn default() -> Self {
         Self {
-            mix: Mix::Clip,
+            mix: Mix::Normal,
             compose: Compose::SrcOver,
         }
     }

--- a/src/impl_bytemuck.rs
+++ b/src/impl_bytemuck.rs
@@ -166,7 +166,10 @@ unsafe impl bytemuck::checked::CheckedBitPattern for Mix {
     type Bits = u8;
 
     fn is_valid_bit_pattern(bits: &u8) -> bool {
-        *bits <= Self::Luminosity as u8 || *bits == Self::Clip as u8
+        #[expect(deprecated, reason = "Mix::Clip is still a valid bit pattern for now.")]
+        *bits
+            <= Self::Luminosity as u8
+            || *bits == Self::Clip as u8
     }
 }
 


### PR DESCRIPTION
A simpler version of #124, to get in before v0.5.0 (which is currently blocked on #134 anyway).