### PR TITLE
Allow ColorStops to be passed to Gradient::with_stops

### DIFF
--- a/peniko/src/gradient.rs
+++ b/peniko/src/gradient.rs
@@ -466,6 +466,18 @@ pub trait ColorStopsSource {
     fn collect_stops(self, stops: &mut ColorStops);
 }
 
+impl ColorStopsSource for ColorStops {
+    fn collect_stops(self, stops: &mut ColorStops) {
+        stops.extend(self.0);
+    }
+}
+
+impl ColorStopsSource for &ColorStops {
+    fn collect_stops(self, stops: &mut ColorStops) {
+        stops.extend(self.iter().copied());
+    }
+}
+
 impl<T> ColorStopsSource for &'_ [T]
 where
     T: Into<ColorStop> + Copy,


### PR DESCRIPTION
This adds `ColorStopsSource` impls for `ColorStops` and `&ColorStops`, letting callers pass an existing stop collection directly into `Gradient::with_stops` without extra slicing or conversion.