### PR TITLE
imaging_model: introduce initial clip-focused model types

### DIFF
--- a/.github/copyright.sh
+++ b/.github/copyright.sh
@@ -7,13 +7,14 @@
 #   -g "!src/special_directory"
 
 # Check all the standard Rust source files
-output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the Peniko Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" .)
+output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the (Peniko|Imaging Model) Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" .)
 
 if [ -n "$output" ]; then
 	echo -e "The following files lack the correct copyright header:\n"
 	echo $output
-	echo -e "\n\nPlease add the following header:\n"
+	echo -e "\n\nPlease add one of the following headers:\n"
 	echo "// Copyright $(date +%Y) the Peniko Authors"
+	echo "// Copyright $(date +%Y) the Imaging Model Authors"
 	echo "// SPDX-License-Identifier: Apache-2.0 OR MIT"
 	echo -e "\n... rest of the file ...\n"
 	exit 1
@@ -21,4 +22,3 @@ fi
 
 echo "All files have correct copyright headers."
 exit 0
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.85"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p peniko"
+  RUST_MIN_VER_PKGS: "-p imaging_model -p peniko"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "imaging_model"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+ "peniko",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["peniko"]
+members = ["imaging_model", "peniko"]
 resolver = "2"
 
 [workspace.package]
@@ -9,6 +9,10 @@ repository = "https://github.com/linebender/peniko"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files,
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 rust-version = "1.85"
+
+[workspace.dependencies]
+kurbo = { version = "0.13.0", default-features = false }
+peniko = { version = "0.6.0", path = "peniko", default-features = false }
 
 [workspace.lints]
 rust.unsafe_code = "deny"

--- a/imaging_model/Cargo.toml
+++ b/imaging_model/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "imaging_model"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Core data model types for Linebender 2D Imaging Model"
+keywords = ["graphics"]
+categories = ["graphics"]
+readme = "README.md"
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
+[features]
+default = ["std"]
+std = ["kurbo/std", "peniko/std"]
+libm = ["kurbo/libm", "peniko/libm"]
+
+[dependencies]
+kurbo = { version = "0.13.0", default-features = false }
+peniko = { workspace = true }
+
+[lints]
+workspace = true

--- a/imaging_model/LICENSE-APACHE
+++ b/imaging_model/LICENSE-APACHE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/imaging_model/LICENSE-MIT
+++ b/imaging_model/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Raph Levien
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/imaging_model/src/clip.rs
+++ b/imaging_model/src/clip.rs
@@ -1,0 +1,366 @@
+// Copyright 2026 the Imaging Model Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{Affine, BezPath, Rect, RoundedRect, Shape as _, Stroke};
+use peniko::Fill;
+
+/// Geometry payload used by [`Clip`] operations.
+///
+/// This enum captures the shape before any operation-specific interpretation.
+/// For [`Clip::Fill`], the geometry interior is used directly. For
+/// [`Clip::Stroke`], the geometry is first stroked and the resulting outline is
+/// used as the clip region.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ClipGeometry {
+    /// Axis-aligned rectangle.
+    Rect(Rect),
+    /// Axis-aligned rounded rectangle.
+    RoundedRect(RoundedRect),
+    /// General path.
+    Path(BezPath),
+}
+
+impl ClipGeometry {
+    /// Is this clip geometry finite?
+    pub fn is_finite(&self) -> bool {
+        match self {
+            Self::Rect(r) => r.is_finite(),
+            Self::RoundedRect(rr) => rr.is_finite(),
+            Self::Path(p) => p.is_finite(),
+        }
+    }
+
+    /// Is this clip geometry NaN?
+    pub fn is_nan(&self) -> bool {
+        match self {
+            Self::Rect(r) => r.is_nan(),
+            Self::RoundedRect(rr) => rr.is_nan(),
+            Self::Path(p) => p.is_nan(),
+        }
+    }
+
+    /// Convert a geometry payload into a path.
+    pub fn to_path(&self, tolerance: f64) -> BezPath {
+        match self {
+            Self::Rect(r) => r.to_path(tolerance),
+            Self::RoundedRect(rr) => rr.to_path(tolerance),
+            Self::Path(p) => p.clone(),
+        }
+    }
+
+    /// Conservative axis-aligned bounds of this geometry.
+    ///
+    /// Returns `None` if the geometry bounds are non-finite.
+    pub fn bounds(&self) -> Option<Rect> {
+        let bounds = match self {
+            Self::Rect(r) => *r,
+            Self::RoundedRect(rr) => rr.bounding_box(),
+            Self::Path(p) => p.bounding_box(),
+        };
+        bounds.is_finite().then_some(bounds)
+    }
+}
+
+/// A clip operation pushed onto the non-isolated clip stack.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Clip {
+    /// Clip to the fill region of a shape.
+    Fill {
+        /// Transform applied to the clip shape.
+        ///
+        /// This does not affect subsequent draws; it only affects how the clip shape is interpreted.
+        transform: Affine,
+        /// Shape used to define the clip region.
+        shape: ClipGeometry,
+        /// Fill rule used to determine the interior for path clips.
+        fill_rule: Fill,
+    },
+    /// Clip to the filled outline of a stroked shape.
+    Stroke {
+        /// Transform applied to the clip shape.
+        ///
+        /// This does not affect subsequent draws; it only affects how the clip shape is interpreted.
+        transform: Affine,
+        /// Shape whose stroked outline defines the clip region.
+        shape: ClipGeometry,
+        /// Stroke style used to compute the outline (including dashes).
+        stroke: Stroke,
+    },
+}
+
+impl Clip {
+    /// Conservative axis-aligned bounds of this clip after applying transform.
+    ///
+    /// Returns `None` if any inputs needed for bounds are non-finite.
+    ///
+    /// ```
+    /// use imaging_model::{Clip, ClipGeometry, Fill};
+    /// use kurbo::{Affine, Rect};
+    ///
+    /// let clip = Clip::Fill {
+    ///     transform: Affine::translate((5.0, -2.0)),
+    ///     shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 2.0, 3.0)),
+    ///     fill_rule: Fill::NonZero,
+    /// };
+    ///
+    /// assert_eq!(clip.bounds(), Some(Rect::new(5.0, -2.0, 7.0, 1.0)));
+    /// ```
+    pub fn bounds(&self) -> Option<Rect> {
+        match self {
+            Self::Fill {
+                transform, shape, ..
+            } => shape
+                .bounds()
+                .map(|bounds| transform.transform_rect_bbox(bounds))
+                .filter(|bounds| bounds.is_finite()),
+            Self::Stroke {
+                transform,
+                shape,
+                stroke,
+            } => shape
+                .bounds()
+                .and_then(|bounds| stroke_bounds(bounds, stroke))
+                .map(|bounds| transform.transform_rect_bbox(bounds))
+                .filter(|bounds| bounds.is_finite()),
+        }
+    }
+
+    /// Is this clip finite?
+    pub fn is_finite(&self) -> bool {
+        match self {
+            Self::Fill {
+                transform, shape, ..
+            } => transform.is_finite() && shape.is_finite(),
+            Self::Stroke {
+                transform,
+                shape,
+                stroke,
+            } => transform.is_finite() && shape.is_finite() && stroke_is_finite(stroke),
+        }
+    }
+
+    /// Is this clip NaN?
+    pub fn is_nan(&self) -> bool {
+        match self {
+            Self::Fill {
+                transform, shape, ..
+            } => transform.is_nan() || shape.is_nan(),
+            Self::Stroke {
+                transform,
+                shape,
+                stroke,
+            } => transform.is_nan() || shape.is_nan() || stroke_is_nan(stroke),
+        }
+    }
+}
+
+fn stroke_is_finite(stroke: &Stroke) -> bool {
+    // TODO(kurbo#545): Replace this local helper with `kurbo::Stroke::is_finite`.
+    stroke.width.is_finite()
+        && stroke.miter_limit.is_finite()
+        && stroke.dash_offset.is_finite()
+        && stroke.dash_pattern.iter().all(|dash| dash.is_finite())
+}
+
+fn stroke_is_nan(stroke: &Stroke) -> bool {
+    // TODO(kurbo#545): Replace this local helper with `kurbo::Stroke::is_nan`.
+    stroke.width.is_nan()
+        || stroke.miter_limit.is_nan()
+        || stroke.dash_offset.is_nan()
+        || stroke.dash_pattern.iter().any(|dash| dash.is_nan())
+}
+
+fn stroke_bounds(bounds: Rect, stroke: &Stroke) -> Option<Rect> {
+    if !stroke_is_finite(stroke) {
+        return None;
+    }
+
+    // Conservative outset to account for width, caps, and miter joins.
+    let outset = 0.5 * stroke.width.abs() * stroke.miter_limit.abs().max(1.0);
+    let expanded = bounds.inflate(outset, outset);
+    expanded.is_finite().then_some(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_is_finite_depends_on_transform_and_shape() {
+        let mut non_finite_path = BezPath::new();
+        non_finite_path.move_to((0.0, 0.0));
+        non_finite_path.line_to((f64::INFINITY, 1.0));
+
+        let finite = Clip::Fill {
+            transform: Affine::translate((3.0, -2.0)),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 10.0, 4.0)),
+            fill_rule: Fill::NonZero,
+        };
+        let non_finite_transform = Clip::Fill {
+            transform: Affine::new([f64::NAN, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 10.0, 4.0)),
+            fill_rule: Fill::NonZero,
+        };
+        let non_finite_shape = Clip::Fill {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Path(non_finite_path),
+            fill_rule: Fill::NonZero,
+        };
+
+        assert!(finite.is_finite());
+        assert!(!non_finite_transform.is_finite());
+        assert!(!non_finite_shape.is_finite());
+    }
+
+    #[test]
+    fn fill_is_nan_depends_on_transform_and_shape() {
+        let finite = Clip::Fill {
+            transform: Affine::translate((3.0, -2.0)),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 10.0, 4.0)),
+            fill_rule: Fill::NonZero,
+        };
+        let nan_transform = Clip::Fill {
+            transform: Affine::new([f64::NAN, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 10.0, 4.0)),
+            fill_rule: Fill::NonZero,
+        };
+        let nan_shape = Clip::Fill {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, f64::NAN, 1.0)),
+            fill_rule: Fill::NonZero,
+        };
+        let infinite_transform = Clip::Fill {
+            transform: Affine::new([f64::INFINITY, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 10.0, 4.0)),
+            fill_rule: Fill::NonZero,
+        };
+
+        assert!(!finite.is_nan());
+        assert!(nan_transform.is_nan());
+        assert!(nan_shape.is_nan());
+        assert!(!infinite_transform.is_nan());
+    }
+
+    #[test]
+    fn stroke_is_finite_depends_on_transform_and_shape() {
+        let finite = Clip::Stroke {
+            transform: Affine::scale(2.0),
+            shape: ClipGeometry::RoundedRect(RoundedRect::from_rect(
+                Rect::new(-1.0, -1.0, 1.0, 1.0),
+                0.25,
+            )),
+            stroke: Stroke::new(3.0),
+        };
+        let non_finite_transform = Clip::Stroke {
+            transform: Affine::new([1.0, 0.0, 0.0, f64::NEG_INFINITY, 0.0, 0.0]),
+            shape: ClipGeometry::RoundedRect(RoundedRect::from_rect(
+                Rect::new(-1.0, -1.0, 1.0, 1.0),
+                0.25,
+            )),
+            stroke: Stroke::new(3.0),
+        };
+        let non_finite_shape = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, f64::NAN, 1.0)),
+            stroke: Stroke::new(3.0),
+        };
+        let non_finite_stroke = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 1.0, 1.0)),
+            stroke: Stroke::new(f64::INFINITY),
+        };
+        let non_finite_dash_pattern = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 1.0, 1.0)),
+            stroke: Stroke::new(2.0).with_dashes(0.0, [1.0, f64::NAN]),
+        };
+
+        assert!(finite.is_finite());
+        assert!(!non_finite_transform.is_finite());
+        assert!(!non_finite_shape.is_finite());
+        assert!(!non_finite_stroke.is_finite());
+        assert!(!non_finite_dash_pattern.is_finite());
+    }
+
+    #[test]
+    fn stroke_is_nan_depends_on_transform_shape_and_stroke() {
+        let finite = Clip::Stroke {
+            transform: Affine::scale(2.0),
+            shape: ClipGeometry::RoundedRect(RoundedRect::from_rect(
+                Rect::new(-1.0, -1.0, 1.0, 1.0),
+                0.25,
+            )),
+            stroke: Stroke::new(3.0),
+        };
+        let nan_transform = Clip::Stroke {
+            transform: Affine::new([1.0, 0.0, 0.0, f64::NAN, 0.0, 0.0]),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 1.0, 1.0)),
+            stroke: Stroke::new(3.0),
+        };
+        let nan_shape = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, f64::NAN, 1.0)),
+            stroke: Stroke::new(3.0),
+        };
+        let nan_stroke = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 1.0, 1.0)),
+            stroke: Stroke::new(2.0).with_dashes(0.0, [1.0, f64::NAN]),
+        };
+        let infinite_stroke = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 1.0, 1.0)),
+            stroke: Stroke::new(f64::INFINITY),
+        };
+
+        assert!(!finite.is_nan());
+        assert!(nan_transform.is_nan());
+        assert!(nan_shape.is_nan());
+        assert!(nan_stroke.is_nan());
+        assert!(!infinite_stroke.is_nan());
+    }
+
+    #[test]
+    fn clip_geometry_bounds() {
+        let rect = ClipGeometry::Rect(Rect::new(1.0, 2.0, 4.0, 8.0));
+        assert_eq!(rect.bounds(), Some(Rect::new(1.0, 2.0, 4.0, 8.0)));
+
+        let rounded =
+            ClipGeometry::RoundedRect(RoundedRect::from_rect(Rect::new(-1.0, -2.0, 3.0, 4.0), 0.5));
+        assert_eq!(rounded.bounds(), Some(Rect::new(-1.0, -2.0, 3.0, 4.0)));
+    }
+
+    #[test]
+    fn clip_bounds_for_fill_and_stroke() {
+        let fill = Clip::Fill {
+            transform: Affine::translate((10.0, -4.0)),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 2.0, 3.0)),
+            fill_rule: Fill::NonZero,
+        };
+        assert_eq!(fill.bounds(), Some(Rect::new(10.0, -4.0, 12.0, -1.0)));
+
+        let stroke = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 2.0, 3.0)),
+            stroke: Stroke::new(2.0).with_miter_limit(4.0),
+        };
+        assert_eq!(stroke.bounds(), Some(Rect::new(-4.0, -4.0, 6.0, 7.0)));
+    }
+
+    #[test]
+    fn clip_bounds_returns_none_for_non_finite_inputs() {
+        let non_finite_fill = Clip::Fill {
+            transform: Affine::new([1.0, 0.0, 0.0, f64::NAN, 0.0, 0.0]),
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 2.0, 3.0)),
+            fill_rule: Fill::NonZero,
+        };
+        assert_eq!(non_finite_fill.bounds(), None);
+
+        let non_finite_stroke = Clip::Stroke {
+            transform: Affine::IDENTITY,
+            shape: ClipGeometry::Rect(Rect::new(0.0, 0.0, 2.0, 3.0)),
+            stroke: Stroke::new(1.0).with_dashes(0.0, [1.0, f64::NAN]),
+        };
+        assert_eq!(non_finite_stroke.bounds(), None);
+    }
+}

--- a/imaging_model/src/lib.rs
+++ b/imaging_model/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright 2026 the Imaging Model Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Data model for describing Linebender imaging operations.
+//!
+//! An imaging model defines the semantic operations an implementation consumes:
+//! what gets drawn, how it is composited, and how stateful operations such as
+//! clipping affect subsequent draws.
+//!
+//! This crate is the initial core of that model. The current scope is
+//! intentionally small, starting with foundational clip-related types and
+//! invariants that are useful across renderers.
+//!
+//! Expect iteration and occasional breaking changes while the model is refined.
+
+#![no_std]
+
+mod clip;
+
+pub use crate::clip::{Clip, ClipGeometry};
+pub use peniko::{BlendMode, Fill};

--- a/peniko/Cargo.toml
+++ b/peniko/Cargo.toml
@@ -31,7 +31,7 @@ serde = [
 ]
 
 [dependencies]
-kurbo = { version = "0.13.0", default-features = false }
+kurbo = { workspace = true }
 smallvec = "1.15.1"
 bytemuck = { version = "1.24.0", default-features = false, optional = true }
 color = { version = "0.3.2", default-features = false }


### PR DESCRIPTION
Introduce a first draft of the `imaging_model` crate with clip-focused model types. The goal is to establish a small, explicit core model that we can evolve as we define the imaging model and move our renderers to using it.