### PR TITLE
peniko: add BlendMode::is_destructive

### DIFF
--- a/peniko/src/blend.rs
+++ b/peniko/src/blend.rs
@@ -170,6 +170,23 @@ impl BlendMode {
     pub const fn new(mix: Mix, compose: Compose) -> Self {
         Self { mix, compose }
     }
+
+    /// Returns whether this blend mode might cause destructive changes in the backdrop.
+    ///
+    /// Destructive blend modes disallow certain optimizations, such as skipping
+    /// transparent paints.
+    #[must_use]
+    pub const fn is_destructive(&self) -> bool {
+        matches!(
+            self.compose,
+            Compose::Clear
+                | Compose::Copy
+                | Compose::SrcIn
+                | Compose::DestIn
+                | Compose::SrcOut
+                | Compose::DestAtop
+        )
+    }
 }
 
 impl Default for BlendMode {


### PR DESCRIPTION
This exposes whether a blend mode can make destructive changes to the backdrop, so renderers can avoid optimizations like skipping transparent paints when they would be invalid.